### PR TITLE
Pause before clicking the stay signed in btn

### DIFF
--- a/src/auth/login.ts
+++ b/src/auth/login.ts
@@ -58,8 +58,11 @@ export const login = async (
   }
 
   await page.waitForTimeout(500);
-  const staySignedInBtn = page.locator(`input[type=submit][value=${staySignedInBtnValue}]`);
-  if (await staySignedInBtn.count() > 0) {
+  const staySignedInBtn = page.locator(
+    `input[type=submit][value=${staySignedInBtnValue}]`
+  );
+  await page.waitForTimeout(500);
+  if ((await staySignedInBtn.count()) > 0) {
     await staySignedInBtn.click();
   }
 


### PR DESCRIPTION
Since I had an issue, that the tests stick at the "stay logged in" modal, I tried to wait before clicking. I incremented the time to wait and 500 was the least time to get it to run. 
Hopefully you can merge this.
![2025-05-09_09h21_05](https://github.com/user-attachments/assets/6841a25e-5de8-4c05-8cba-d3be51560ad9)
